### PR TITLE
Fix incorrect Zul'Aman raid map ID (1977 → 568)

### DIFF
--- a/ZoneDetails.lua
+++ b/ZoneDetails.lua
@@ -948,7 +948,7 @@ zones[1942] = {
     low = 10,
     high = 20,
     continent = Eastern_Kingdoms,
-    raids = {1977},
+    raids = {568},
     faction = "Horde",
     fishing_min = 20,
     herbs = {"Peacebloom", "Silverleaf", "Earthroot", "Mageroyal", "Briarthorn", "Stranglekelp", "Bruiseweed"},
@@ -1959,7 +1959,7 @@ raids[564] = {
 }
 
 -- Zul'Aman
-raids[1977] = {
+raids[568] = {
     low = 70,
     high = 70,
     players = 10,


### PR DESCRIPTION
## Summary

While validating that every map ID in the addon is correct and available across all supported Classic versions (Vanilla 1.15, TBC 2.5, Wrath 3.4, MoP 5.5), one misconfigured ID was found.

The **Zul'Aman** TBC raid was registered as `raids[1977]`. `1977` is not a valid instance map ID — every other instance and raid in the addon uses its canonical `Map.dbc` instance ID, and the MoP Classic data block already references the very same instance correctly as `instances[568]`.

Because the raid is rendered via `GetRealZoneText(raid)` (both for the Ghostlands zone text and for the raid entrance pin), the wrong ID caused `GetRealZoneText(1977)` to return nothing, so on TBC and Wrath clients Zul'Aman appeared with a **blank name** in the zone text and a **blank tooltip** on its map pin.

## Changes

- `raids[1977]` → `raids[568]` (the correct Zul'Aman instance map ID)
- Ghostlands `zones[1942].raids = {1977}` → `{568}` to match

## Validation notes (no other changes needed)

I cross-checked every `zones[...]` uiMapID and every instance/raid/battleground/complex map ID against the canonical values:

- **Base table (Vanilla/TBC/Wrath)** — all Eastern Kingdoms/Kalimdor `14xx` and TBC/Outland `19xx` uiMapIDs are correct, and all instance/raid IDs match their `Map.dbc` IDs. Zul'Aman was the only outlier.
- **MoP block (`if isMoP`)** — all retail-style uiMapIDs (`1`–`554`) and all WotLK/Cata/MoP instance, raid, and battleground IDs are correct.
- Version gating is sound: the base table serves Vanilla/TBC/Wrath, and the retail-ID block is correctly scoped to MoP.

## Testing

- Confirmed no remaining `1977` references.
- Lua syntax validated for `ZoneDetails.lua`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3FsF7qJ2qNZmzqx9PUfUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3FsF7qJ2qNZmzqx9PUfUx)_